### PR TITLE
Change pubsub get_message API timeout to seconds. (#864)

### DIFF
--- a/common/pubsub.cpp
+++ b/common/pubsub.cpp
@@ -93,7 +93,7 @@ MessageResultPair PubSub::get_message_internal(double timeout, bool interrupt_on
     }
 
     Selectable *selected;
-    int rc = m_select.select(&selected, int(timeout), interrupt_on_signal);
+    int rc = m_select.select(&selected, int(timeout * 1000), interrupt_on_signal);
     ret.first = rc;
     switch (rc)
     {

--- a/common/pubsub.h
+++ b/common/pubsub.h
@@ -18,6 +18,11 @@ class PubSub : protected RedisSelect
 public:
     explicit PubSub(DBConnector *other);
 
+    /**
+     * @brief Get published message 
+     * @param timeout                Get message timeout in seconds
+     * @param interrupt_on_signal    Interrupt when reseive EINTR signal
+     */
     std::map<std::string, std::string> get_message(double timeout = 0.0, bool interrupt_on_signal = false);
     std::map<std::string, std::string> listen_message(bool interrupt_on_signal = false);
 


### PR DESCRIPTION
Sync PR https://github.com/sonic-net/sonic-swss-common/pull/864

> > Change pubsub get_message API timeout to seconds.
> 
> ### Why I did it
> In redis-py library the pubsub timeout is seconds, to keep compatibility, change pubsub get_message API timeout to seconds.
> The only code using pubsub get_message API with timeout is frrcfgd, change this API will not break any other code in SONiC.
> 
> ### How I did it
> Change pubsub get_message API timeout to seconds.